### PR TITLE
chore: change the client cli path to common-nestjs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ env.GENERATE_CLIENT == 'true' }}
         run: |
           npm run build
-          ts-node -r tsconfig-paths/register ./node_modules/@candisio/common/lib/cli.js generate-swagger --appModuleSrc=/src/app.module.ts && cd ./packages/sdk && npm run oapi-generate
+          ts-node -r tsconfig-paths/register ./node_modules/@candisio/common-nestjs/lib/cli.js generate-swagger --appModuleSrc=/src/app.module.ts && cd ./packages/sdk && npm run oapi-generate
 
       - name: "Version and publish - Packages"
         env:


### PR DESCRIPTION
# [Issue TCP-909](https://candis.atlassian.net/browse/TCP-909)

## What's implemented?

With new candis common package separations, now CLI has moved to the `common-nestjs`, in this PR adapting the path changes. 

