### PR TITLE
Not needed. Default policy is appropriate

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -66,14 +66,12 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
-          POLICY_TEXT: ${{secrets.AWS_ECR_REPOSITORY_ACCESS_POLICY}}
         run: |
           EXIT_CODE=0
           ECR_REGISTRY_ID=${ECR_REGISTRY%%.*}
           aws ecr describe-repositories --repository-name $ECR_REPOSITORY --registry-id $ECR_REGISTRY_ID || EXIT_CODE=$?
           if [ $EXIT_CODE -eq 254 ]; then
             aws ecr create-repository  --repository-name $ECR_REPOSITORY --registry-id $ECR_REGISTRY_ID
-            aws ecr set-repository-policy --registry-id $ECR_REGISTRY_ID --repository-name $ECR_REPOSITORY --policy-text $POLICY_TEXT
           fi
 
       - name: Build, tag, and push image to Amazon ECR


### PR DESCRIPTION
Not needed. I added it by copying it from [here](https://github.com/CandisIO/.github/pull/1/files#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R74). It doesn't work and the default policy set is appropriate